### PR TITLE
Don't use JShrink on PHP 8

### DIFF
--- a/infection.json.dist
+++ b/infection.json.dist
@@ -10,6 +10,8 @@
     },
      "mutators": {
          "@default": true,
+         "LessThan": false,
+         "LessThanNegotiation": false,
          "Ternary": {
              "ignore": [
                  "WyriHaximus\\JsCompress\\Factory::constructSmallest"

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -13,6 +13,7 @@ use WyriHaximus\JsCompress\Compressor\JSMinCompressor;
 use WyriHaximus\JsCompress\Compressor\MMMJSCompressor;
 use WyriHaximus\JsCompress\Compressor\YUIJSCompressor;
 
+use const PHP_VERSION_ID;
 use const WyriHaximus\Constants\Boolean\TRUE_;
 
 final class Factory
@@ -31,7 +32,7 @@ final class Factory
             new MMMJSCompressor(),
             new JSMinCompressor(),
             new JavaScriptPackerCompressor(),
-            new JShrinkCompressor(),
+            PHP_VERSION_ID < 80000 ? new JShrinkCompressor() : new ReturnCompressor(),
             $externalCompressors ? new YUIJSCompressor() : new ReturnCompressor(),
             new ReturnCompressor() // Sometimes no compression can already be the smallest
         );


### PR DESCRIPTION
JShrink has some issues on PHP 8, found the issue while working on https://github.com/WyriHaximus/HtmlCompress/pull/113 so disabling it for PHP 8 only until it's fixed upstream.